### PR TITLE
Add names to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2020 UCSC CSE 123 2020 
+Copyright (c) 2020 Alexis Chavez, Jorge Henriquez, Kevin Jesubalan,
+Natan Lao, Bryan Munoz Garcia, and Jennie Nguyen 2020 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #10. gRPC is Apache and sqlite is public domain, so we don't need to worry about either of those. We should screen new dependencies, though.

Sorry, @penguingovernor, I didn't see that you already added this!