### PR TITLE
Client initial commit (closes #11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server/db/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,6 +11,12 @@ This project uses gRPC for communication between sensors and the server primaril
 
 SQLite is a lightweight option that best serves both of those criteria, in addition to being simple to implement and requiring minimal administration.
 
+### Why no REST API?
+
+The server exposes transit data to the client by serving the entire SQLite database at once. This is possible for the reasons listed above, and also because the data that we're storing is incredibly lightweight. Furthermore, this data is generally considered infrequently in its entirety -- not just segments of it. For this reason, implementing some kind of REST API between the client and an underlying database seems to be overkill.
+
+See #17 for further discussion.
+
 ## Why software as a product over software as a service?
 
 Simplicity for the purposes of designing a minimum viable product as quickly as possible. Pivoting this project to the SaaS model is theoretically trivial, but would require implementation of other features such as user login and authentication that are not listed in the project's design objectives.
@@ -20,3 +26,4 @@ Simplicity for the purposes of designing a minimum viable product as quickly as 
 If this project is being constructed as a product and not a service, and it is being constructed for a university client (e.g., UCSC TAPS) then were it self hosted it might be hosted using [UCSC ITS Virtual Server Hosting](https://its.ucsc.edu/data-center/virtual-server-hosting.html). Using Docker would, in theory, make it easier to deploy this project using that service, and has the added benefit of reducing vendor lock-in.
 
 This project is small enough that it would likely be much cheaper to implement as a set of Lambdas, etc. but there is a realistic chance that self-hosting on such platforms could be prohibitive for a university client.
+

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.17.10-alpine
+COPY . /usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  web:
+    build: 'client/'
+    ports:
+      - '8080:80'
+    volumes:
+      - './server/db/:/usr/share/nginx/html/db/'
+    environment:
+      NGINX_PORT: '80'

--- a/server/main.go
+++ b/server/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	db, err := sql.Open("sqlite3", "./busdata.db")
+	db, err := sql.Open("sqlite3", "server/db/taps.db")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Proposing a change of plan here. The new plan is that we don't write some REST API that queries a database and exposes the results of the query as JSON. Instead, we serve the entire sqlite3 database file, download it to the client, and manipulate it on-client. This makes #11 very, very easy to close.

Some thoughts:
* We can do this because the database will almost always be incredibly small. If I'm interpreting the data correctly - which I may not be -`sqlite3_analyzer` says that each row in the db given our schema consumes on average 21 bytes. This means that some client could have ten buses pinging the server once a minute 24/7/365, and after nine years, the database wouldn't even consume a gigabyte of storage space.
* There appear to be mature libraries for querying sqlite3 database in-browser https://github.com/sql-js/sql.js
* This approach makes sense given our design objectives / target audience / their capabilities. This data does not need to be accessed in real time, and would likely be accessed infrequently, which gives us a lot of leeway.

In theory - to spitball this idea a little more - sqlite3 is so lightweight, and the data we are collecting even more so, that I think this approach would be feasible in a world where we had to serve multiple clients simultaneously.