### PR TITLE
Shut down the server gracefully

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -26,6 +26,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to connect to db: %s\n", err)
 	}
+	defer db.Close()
 
 	// Init. the database and inject the dependency
 	// into the server.
@@ -38,5 +39,4 @@ func main() {
 	if err := srv.Serve(flags.Host, flags.Port); err != nil {
 		log.Fatalf("server failed to start: %s", err)
 	}
-
 }


### PR DESCRIPTION
Adds a signal handler so that Ctrl-C and `docker-compose down` do not exit with
nonzero exit codes.